### PR TITLE
Pg/improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDEs #
+.DS_Store
+
 /db-backup/*
 /logs/*
 /versions-override/*

--- a/Readme.md
+++ b/Readme.md
@@ -133,13 +133,13 @@ Additionally you can put additional scripts there and add it to update-script.sh
     * ```BASE_CMS_VERSION='10.4'``` (Starting version)
 2. run sync script
 3. Checkout new branch for 10.4: ```git checkout -b typo3-10.4```
-5. Create root-.env with CMS_VERSIONS and CURRENT_CMS_VERSION
+5. Create root-.env.t3upgrader with CMS_VERSIONS and CURRENT_CMS_VERSION
     * ```CMS_VERSIONS='10.4'```
     * ```CURRENT_CMS_VERSION='10.4'```
 6. commit state, because upgrader will switch between branches
 7. ```./t3upgrader/t3upgrade.sh```
 9. Checkout new branch for 11.5: ```git checkout -b typo3-11.5```
-10. Adjust root-.env
+10. Adjust root-.env.t3upgrader
     * ```CMS_VERSIONS='10.4 11.5'```
     * ```CURRENT_CMS_VERSION='11.5’```
 11. set needed package versions and php version to composer.json, set needed php version to .ddev/config
@@ -148,7 +148,7 @@ Additionally you can put additional scripts there and add it to update-script.sh
 12. commit state, because upgrader will switch between branches
 13. ```./t3upgrader/t3upgrade.sh```
 14. Checkout new branch for 12.4: ```git checkout -b typo3-12.4```
-15. Root-.env anpassen
+15. Root-.env.t3upgrader anpassen
     * ```CMS_VERSIONS='10.4 11.5 12.4’```
     * ```CURRENT_CMS_VERSION='12.4’```
 16. set needed package versions and php version to composer.json, set needed php version to .ddev/config

--- a/t3upgrade.sh
+++ b/t3upgrade.sh
@@ -30,37 +30,37 @@ splitVersions() {
 }
 
 initUpgrade() {
-  echo "Create DB Backup Dir"
+  echoStep "Create DB Backup Dir \n mkdir -p ${DB_BACKUP_DIR}/${version}"
   mkdir -p ${DB_BACKUP_DIR}/${version}
 
   if [ "${version}" = "${BASE_CMS_VERSION}" ]; then
-    echo "Copy Production DB"
+    echoStep "Copy Production DB \n cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
     cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
   else
-    echo "Export current DB ..."
+    echoStep "Export current DB ... \n ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
     ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
   fi
 
-  echo "Checkout ${version} branch ..."
+  echoStep "Checkout ${version} branch ... \n git checkout ${BRANCH_PREFIX}-${version}"
   git checkout ${BRANCH_PREFIX}-${version}
 }
 
 importCleanDB() {
-  echo "Stop DDEV ..."
+  echoStep "Stop DDEV ... \n ddev stop"
   ddev stop
 
-  echo "Clean DDEV ..."
+  echoStep "Clean DDEV ... \n ddev delete --omit-snapshot --yes"
   ddev delete --omit-snapshot --yes
 
-  echo "Start DDEV ..."
+  echoStep "Start DDEV ... \n ddev start"
   ddev start
 
-  echo "Import previous DB ..."
+  echoStep "Import previous DB ... \n ddev import-db --file=${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
   ddev import-db --file=${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
 }
 
 cleanFolders() {
-  echo "Clean Folders ..."
+  echoStep "Clean Folders ..."
   rm -rf ./public/typo3conf/ext && rm -rf ./public/typo3conf/l10n
   rm -rf ./public/_assets && rm -rf ./public/typo3 && rm -rf ./public/index.php
   rm -rf ./var && rm -rf ./public/typo3temp
@@ -77,21 +77,26 @@ composerInstall() {
 }
 
 updateTYPO3() {
-  echo "Update TYPO3"
+  echoStep "Update TYPO3 \n ddev exec ${VERSIONS_DIR}/${version}/update-script.sh"
   ddev exec ${VERSIONS_DIR}/${version}/update-script.sh
 }
 
 finishUpgrade() {
-  echo "Export current DB ..."
+  echoStep "Export current DB ... \n ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}-final.sql.gz"
   ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}-final.sql.gz
 
   # If not last version, stop DDEV and continue with next version
   if [ "${version}" != "${LAST_VERSION}" ]; then
-    echo "DDEV Stop ..."
+    echoStep "DDEV Stop ... \n ddev stop"
     ddev stop
   else
-    echo "Upgrade finished!"
+    echoStep "Upgrade finished!"
   fi
+}
+
+# issue echo commands with more visual means
+echoStep() {
+    echo -e "\n\033[1;34m==> $1\033[0m\n"
 }
 
 # Loop through versions and upgrade step by step

--- a/t3upgrade.sh
+++ b/t3upgrade.sh
@@ -34,8 +34,16 @@ initUpgrade() {
   mkdir -p ${DB_BACKUP_DIR}/${version}
 
   if [ "${version}" = "${BASE_CMS_VERSION}" ]; then
-    echoStep "Copy Production DB \n cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
-    cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
+
+    # put backup-file in t3upgrader-path
+    # if it is plain sql, we have to compress it before
+    if [[ "$BASE_DB" == *.sql ]]; then
+      echoStep "DB base dump is plain .sql-file – compressing with gzip and copy... \n gzip -c ${BASE_DB} > ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
+      gzip -c ${BASE_DB} > ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
+    else
+      echoStep "Copy Production DB \n cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
+      cp ${BASE_DB} ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz
+    fi
   else
     echoStep "Export current DB ... \n ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz"
     ddev export-db -z -f ${DB_BACKUP_DIR}/${version}/typo3-db-${version}.sql.gz

--- a/t3upgrade.sh
+++ b/t3upgrade.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# set -x
-# set -e
+# stop script when an error occured
+set -e
 
 # Get base Settings
 if [ -f ${BASH_SOURCE%/*}/.env ]; then


### PR DESCRIPTION
- Readme: Bessere Bezeichnungen: root-.envzu root-.env.t3upgrader
- upgrade-Skript: Verbesserte optische Ausgabe der echo-Befehle, um sie von den Befehl-Ausgaben zu unterscheiden
- Wenn Fehler auftritt: Stoppe Skript
- Wenn die DB Backup Datei blanke sql-Datei ist, dann zippe sie vor dem kopieren in t3upgrader/backup
- .DS_Store in .gitignore